### PR TITLE
Add sidebar uploads and flexible filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ You will be prompted to upload the following Excel files:
 
 After uploading the **AM LOG** file, the app shows the filtered rows containing
 only the columns Delivery Date, Customer Reference, Serial number, Year of
-construction and Month of construction.
+construction and Month of construction. Upload buttons and filtering controls
+are available in the sidebar. The year and month of construction are
+automatically derived from the Delivery Date. The sidebar also lists the
+equipment numbers used for filtering and lets you add or remove them.
 
 
 Equipment numbers are treated as strings so leading zeros are preserved. If your
 file stores them as numbers, the app converts that column with `astype(str)` so
 matching works even if pandas originally inferred a numeric type.
-=======
-


### PR DESCRIPTION
## Summary
- place upload widgets and filtering controls in Streamlit sidebar
- allow adding or disabling material numbers via sidebar
- extract year and month from Delivery Date
- show how many lines are removed after filtering
- update README with new instructions

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688732c03a7c83269c16359b644f1e01