### PR TITLE
Improve filtering UI and ZSD join

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ You will be prompted to upload the following Excel files:
 
 After uploading the **AM LOG** file, the app shows the filtered rows containing
 only the columns Delivery Date, Customer Reference, Serial number, Year of
-construction and Month of construction.
+construction and Month of construction. Upload buttons and filtering controls
+are available in the sidebar. The year and month of construction are
+automatically derived from the Delivery Date. The sidebar also lists the
+equipment numbers used for filtering and lets you add or remove them.
+
+If you also upload the **ZSD_PO_PER_SO** sheet, rows are enriched with the
+matching *Document* and *Material* columns when `Customer Reference` values from
+AM LOG correspond to `Document` values in ZSD_PO_PER_SO.
 
 
 Equipment numbers are treated as strings so leading zeros are preserved. If your
 file stores them as numbers, the app converts that column with `astype(str)` so
 matching works even if pandas originally inferred a numeric type.
-=======
-

--- a/app.py
+++ b/app.py
@@ -52,9 +52,26 @@ st.write(
     "Upload the three Excel sheets: 'AM LOG', 'ZSD_PO_PER_SO' and 'ZSTATUS'."
 )
 
-am_log_file = st.file_uploader("Upload AM LOG", type=["xls", "xlsx"])
-zsd_file = st.file_uploader("Upload ZSD_PO_PER_SO", type=["xls", "xlsx"])
-status_file = st.file_uploader("Upload ZSTATUS", type=["xls", "xlsx"])
+st.sidebar.header("Uploads")
+am_log_file = st.sidebar.file_uploader("Upload AM LOG", type=["xls", "xlsx"])
+zsd_file = st.sidebar.file_uploader("Upload ZSD_PO_PER_SO", type=["xls", "xlsx"])
+status_file = st.sidebar.file_uploader("Upload ZSTATUS", type=["xls", "xlsx"])
+
+st.sidebar.header("Filtering")
+# Allow users to add additional material numbers via text area
+extra_numbers_text = st.sidebar.text_area(
+    "Additional material numbers (one per line)",
+    value="",
+)
+extra_numbers = [n.strip() for n in extra_numbers_text.splitlines() if n.strip()]
+
+# Combine default and additional numbers then let the user select which to use
+all_numbers = MATERIAL_NUMBERS + extra_numbers
+selected_numbers = st.sidebar.multiselect(
+    "Material numbers for filtering",
+    options=all_numbers,
+    default=MATERIAL_NUMBERS,
+)
 
 if am_log_file is not None:
     # Read all data as strings so material numbers keep their leading zeros
@@ -62,14 +79,49 @@ if am_log_file is not None:
     # Strip whitespace from column names to avoid mismatches
     am_log_df.columns = am_log_df.columns.str.strip()
 
+    # Extract year and month from Delivery Date into construction columns
+    if AM_LOG_COLUMNS["Delivery Date"] in am_log_df.columns:
+        delivery_dates = pd.to_datetime(
+            am_log_df[AM_LOG_COLUMNS["Delivery Date"].strip()], errors="coerce"
+        )
+        am_log_df[AM_LOG_COLUMNS["Year of construction"]] = (
+            delivery_dates.dt.year.astype("Int64").astype(str)
+        )
+        am_log_df[AM_LOG_COLUMNS["Month of construction"]] = (
+            delivery_dates.dt.month.astype("Int64").astype(str).str.zfill(2)
+        )
+
     missing_cols = [
         col for col in AM_LOG_COLUMNS.values() if col not in am_log_df.columns
     ]
     if missing_cols:
         st.error(f"Missing columns in AM LOG: {', '.join(missing_cols)}")
     else:
-        material_col = am_log_df[AM_LOG_COLUMNS["Material Number"]].astype(str).str.strip()
-        filtered = am_log_df[material_col.isin(MATERIAL_NUMBERS)]
+        material_col = (
+            am_log_df[AM_LOG_COLUMNS["Material Number"]].astype(str).str.strip()
+        )
+        filtered = am_log_df[material_col.isin(selected_numbers)]
+
+        removed_count = len(am_log_df) - len(filtered)
+
+        # If a ZSD_PO_PER_SO file is uploaded, join relevant columns
+        if zsd_file is not None:
+            zsd_df = pd.read_excel(zsd_file, dtype=str)
+            zsd_df.columns = zsd_df.columns.str.strip()
+            if {"Document", "Material"}.issubset(zsd_df.columns):
+                zsd_df = zsd_df[["Document", "Material"]]
+                zsd_df["Document"] = zsd_df["Document"].astype(str).str.strip()
+                merged = filtered.merge(
+                    zsd_df,
+                    left_on=AM_LOG_COLUMNS["Customer Reference"],
+                    right_on="Document",
+                    how="left",
+                )
+            else:
+                st.warning("ZSD_PO_PER_SO missing 'Document' or 'Material' columns")
+                merged = filtered.copy()
+        else:
+            merged = filtered.copy()
 
         output_columns = [
             AM_LOG_COLUMNS["Delivery Date"],
@@ -78,7 +130,12 @@ if am_log_file is not None:
             AM_LOG_COLUMNS["Year of construction"],
             AM_LOG_COLUMNS["Month of construction"],
         ]
-        st.write("Filtered AM LOG")
-        st.dataframe(filtered[output_columns])
+        if zsd_file is not None and {"Document", "Material"}.issubset(merged.columns):
+            output_columns.extend(["Document", "Material"])
+
+        st.write(
+            f"Filtered AM LOG - removed {removed_count} of {len(am_log_df)} rows"
+        )
+        st.dataframe(merged[output_columns])
 else:
     st.info("Waiting for AM LOG file upload")


### PR DESCRIPTION
## Summary
- move uploads and filters to the sidebar
- allow custom equipment numbers and enable/disable them
- derive year and month from Delivery Date
- show how many rows were removed
- merge with ZSD_PO_PER_SO when provided
- only show Document/Material columns when present in the merge
- document new sidebar and join behaviour

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688732c03a7c83269c16359b644f1e01